### PR TITLE
ci: allow changes that change no images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,9 @@ jobs:
       matrix: ${{ steps.changed-files.outputs.all_modified_files }}
 
   build:
-    needs: generate-matrix
     runs-on: ubuntu-latest
+    needs: generate-matrix
+    if: ${{ needs.generate-matrix.outputs.matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -87,10 +88,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # This is used so that we have one job that is successful once all the matrix builds are done
+  build-skip:
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    if: ${{ needs.generate-matrix.outputs.matrix == '[]' }}
+    steps:
+      - run: echo "No images changed, no build necessary"
+
+  # This is used so that we have one job that is successful once all the matrix builds are done
   build-results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, build-skip]
     steps:
       - run: exit 1
         # see https://stackoverflow.com/a/67532120/4907315


### PR DESCRIPTION
This allows PRs to not modify any images, e.g. if they just modify the documentation.
