### PR TITLE
ci: move packages to oci-images, enable re-build of all images with workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -18,7 +19,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Get changed files
+      - name: Get changed images
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: changed-files
         uses: tj-actions/changed-files@54849deb963ca9f24185fb5de2965e002d066e6b # v37.0.5
         with:
@@ -29,10 +31,25 @@ jobs:
           escape_json: false
 
       - name: List all changed files
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: echo ${{ steps.changed-files.outputs.all_modified_files }}
 
+      - name: Get all images
+        id: all-files
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo images=$(find images/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | jq -R -s -c 'split("\n") | map(select(length > 0))') >> $GITHUB_OUTPUT
+
+      - name: Set matrix
+        id: matrix
+        run: |
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo matrix=${{ steps.changed-files.outputs.all_modified_files }} >> $GITHUB_OUTPUT
+          else
+            echo matrix=${{ steps.all-files.outputs.images }} >> $GITHUB_OUTPUT
+          fi
+
     outputs:
-      matrix: ${{ steps.changed-files.outputs.all_modified_files }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
 
   build:
     runs-on: ubuntu-latest
@@ -72,7 +89,7 @@ jobs:
           flavor: |
             latest=false
           images: |
-            ghcr.io/community-tooling/${{ matrix.image }}
+            ghcr.io/community-tooling/oci-images/${{ matrix.image }}
           tags: |
             type=ref,event=pr
             type=sha


### PR DESCRIPTION
With this PR, images are moved to the `oci-images` path in the registry.

It also adds a `worfklow_dispatch` handler to the image build so that a rebuild of all images can be triggered manually.
