### PR TITLE
chore: ignore mailtrain

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,5 +30,6 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "python/cpython"
     }
-  ]
+  ],
+  "ignorePaths": ["images/mailtrain"]
 }


### PR DESCRIPTION
Ignore the mailtrain image for now since it is so severely outdated that we cannot do anything about it right now.
