### PR TITLE
ci: remove unused tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,6 @@ jobs:
           images: |
             ghcr.io/community-tooling/oci-images/${{ matrix.image }}
           tags: |
-            type=ref,event=pr
-            type=sha
             type=raw,value=${{ steps.calver.outputs.version }}
 
       - name: Build and push


### PR DESCRIPTION
We don't need sha tags. Our versioning is sufficient for now.
