### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default
+* @community-tooling/maintainers
+
+# Images built specifically for infrastructure that @morremeyer runs. Can be changed to be more versatile, but for now, he owns these
+/images/mailtrain @morremeyer


### PR DESCRIPTION
This adds codeowners for the different parts of the repo.
