### PR TITLE
chore: fix renovate python version extraction

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,5 +31,12 @@
       "depNameTemplate": "python/cpython"
     }
   ],
+  "packageRules": [
+    {
+      "matchDatasources": ["github-tags"],
+      "matchPackageNames": ["python/cpython"],
+      "extractVersion": "^v(?<version>.*)$"
+    }
+  ],
   "ignorePaths": ["images/mailtrain"]
 }


### PR DESCRIPTION
We don't need the `v`.
