### PR TITLE
fix: make oauth domain of semaphore dynamic

### DIFF
--- a/images/semaphore/Dockerfile
+++ b/images/semaphore/Dockerfile
@@ -5,7 +5,15 @@ ENV SEMAPHORE_VERSION=1.0.0
 RUN wget -q -O semaphore.zip https://github.com/NickColley/semaphore/archive/refs/tags/${SEMAPHORE_VERSION}.zip
 RUN unzip semaphore.zip && mv /semaphore-${SEMAPHORE_VERSION} /semaphore
 WORKDIR /semaphore
+
+# Make oauth website dynamic until https://github.com/NickColley/semaphore/pull/71 is merged and released.
+# Pinning apk packages tends to break because old versions are immediately removed from their mirrors.
+# hadolint ignore=DL3018
+RUN apk add --no-cache sed && \
+    sed -i 's/website: WEBSITE/website: basename(instanceName)/' src/routes/_api/oauth.js
+
 RUN yarn --production --pure-lockfile && yarn build
+
 
 FROM --platform=${BUILDPLATFORM} nginx:1.25.1-alpine-slim@sha256:f9daf8c7ddd6a86ff1f6bfaab3a0766a471307943e3b2c2f617f51e8c7611925
 COPY --from=builder /semaphore/__sapper__/export /usr/share/nginx/html/

--- a/images/semaphore/README.md
+++ b/images/semaphore/README.md
@@ -2,4 +2,6 @@
 
 [Semaphore](https://github.com/NickColley/semaphore) is an accessible, simple and fast web client for Mastodon.
 
-The upstream project does not provide a Docker image, so this repo automatically builds and releases an image for each new upstream release. The container runs nginx and listens on port 80.
+- The upstream project does not provide a Docker image, so this repo automatically builds and releases an image for each new upstream release.
+- The upstream project hardcodes the oauth website to the official Semaphore website. So until https://github.com/NickColley/semaphore/pull/71 is merged and released we apply a mainimal patch in the [Dockerfile](./Dockerfile) to make it dynamic.
+- The container runs nginx and listens on port 80.


### PR DESCRIPTION
Patching upstream code during build until https://github.com/NickColley/semaphore/pull/71 is merged and released.