### PR TITLE
chore(deps): revert update dependency python/cpython to v3.11.5

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
-          python-version: 3.11.5
+          python-version: 3.11.4
 
       - name: Cache pre-commit dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3


### PR DESCRIPTION
Reverts community-tooling/oci-images#82 since this version is not available yet.