### PR TITLE
fix: sshd_config for ADS-1700W

### DIFF
--- a/images/sshd/Dockerfile
+++ b/images/sshd/Dockerfile
@@ -1,5 +1,9 @@
-FROM --platform=${BUILDPLATFORM} alpine:3.18.3@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
+FROM alpine:3.18.3@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a
 
+# Pinning the openssh version here does not work well since we can't upgrade the alpine version and the
+# openssh version with the same PR, see https://github.com/renovatebot/renovate/discussions/10452.
+# Therefore, we opt to not do this at all for now.
+#
 # hadolint ignore=DL3018
 RUN apk add --no-cache openssh
 

--- a/images/sshd/sshd_config
+++ b/images/sshd/sshd_config
@@ -6,9 +6,12 @@ HostKey /etc/ssh/keys/ssh_host_ed25519_key
 HostKey /etc/ssh/keys/ssh_host_rsa_key
 HostKey /etc/ssh/keys/ssh_host_ecdsa_key
 
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,hmac-sha1
+# Use defaults and add by now unsafe options that the Brother ADS-1700W uses
+HostKeyAlgorithms +ssh-rsa
+PubkeyAcceptedKeyTypes +ssh-rsa
+Ciphers +aes128-ctr
+KexAlgorithms +diffie-hellman-group-exchange-sha1
+MACs +hmac-sha1
 
 # Logging
 SyslogFacility AUTH


### PR DESCRIPTION
This fixes the sshd_config to work with the Brother ADS-1700W again.
It also updates the config to not explicitly specify all ciphers, but only add the ones we need.
