### PR TITLE
chore: automerge python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,8 @@
     {
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["python/cpython"],
-      "extractVersion": "^v(?<version>.*)$"
+      "extractVersion": "^v(?<version>.*)$",
+      "automerge": true
     }
   ],
   "ignorePaths": ["images/mailtrain"]


### PR DESCRIPTION
Since the python version is used by pre-commit and pre-commit is required, we can automerge the python version.
