### PR TITLE
chore(major): change versioning scheme to semver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
             echo exists=false >> $GITHUB_OUTPUT
           fi
 
+      - name: Install semver tool
+        run: wget -O /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.4.0/src/semver && chmod +x /usr/local/bin/semver
+
       - name: Set up QEMU
         if: ${{ steps.dir-check.outputs.exists == 'true' }}
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -86,11 +89,29 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate datever tag
-        if: ${{ steps.dir-check.outputs.exists == 'true' }}
-        id: calver
+      - name: Get most recent tag
+        id: tag
+        run: echo tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | last') >> $GITHUB_OUTPUT
+
+      - name: Get commit scope
+        id: commit-scope
+        env:
+          # Use the PR title if it exists since we use this as the commit message on squashing
+          MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
         run: |
-          echo version="1.$(date +%-Y%m%d.%s)" >> $GITHUB_OUTPUT
+          scope=$(echo $MESSAGE | head -n 1 | sed -E 's/^.*\(([a-z]+)\).*$/\1/g')
+          if [[ "$scope" =~ ^(major|minor|patch)$ ]]; then
+            echo scope=$scope >> $GITHUB_OUTPUT
+          else
+            echo "::error title=Invalid commit scope::The commit scope is not an allowed value, check the README section on versioning"
+            exit 1
+          fi
+
+      - name: Generate tag
+        if: ${{ steps.dir-check.outputs.exists == 'true' }}
+        id: version
+        run: |
+          echo version="$(semver bump ${{ steps.commit-scope.outputs.scope }} ${{ steps.tag.outputs.tag }})" >> $GITHUB_OUTPUT
 
       - name: Docker meta
         if: ${{ steps.dir-check.outputs.exists == 'true' }}
@@ -102,7 +123,7 @@ jobs:
           images: |
             ghcr.io/community-tooling/oci-images/${{ matrix.image }}
           tags: |
-            type=raw,value=${{ steps.calver.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }}
 
       - name: Build and push
         if: ${{ steps.dir-check.outputs.exists == 'true' }}
@@ -110,7 +131,7 @@ jobs:
         with:
           context: images/${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@ Check out the different directories in [`images`](images/)
 
 ## Versioning
 
-Currently, all images are automatically versioned in a prefixed calver style. This does not tell us anything about the versions of the software in the image, but it fulfills the Semantic Versioning 2.0.0 specification and allows us to change to e.g. actual semantic versioning or another format later by bumping the major version.
+Images are versioned automatically based on the semantic commit scope of the commit changing them.
+This means that your Pull request needs to specify the kind of version bump that should be done in the tile
 
-The format looks as follows:
+Valid scopes are: `major`, `minor`, `patch`
+
+**Examples for PR titles**
 
 ```
-1.YYYYMMDD.t
+feat(minor): Add new functionality
+fix(major): Fix a bug, but the fix is a breaking change
+fix(patch): Fix a bug without breaking things
+chore(patch): Update dependencies
 ```
 
-with `YYYYMMDD` being the date of publishing and `t` the unix timestamp.
+renovate is configured to automatically apply the `major` and `minor` scope to the respective updates and the `patch` scope to all other commits it creates.
 
 ## Requirements for images
 

--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,13 @@
   "semanticCommits": "enabled",
   "platformAutomerge": true,
   "automerge": true,
+  "semanticCommitScope": "patch",
   "major": {
-    "automerge": false
+    "automerge": false,
+    "semanticCommitScope": "major"
+  },
+  "minor": {
+    "semanticCommitScope": "minor"
   },
   "regexManagers": [
     {
@@ -30,6 +35,15 @@
       "matchStrings": ["python-version:\\s(?<currentValue>.*)"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "python/cpython"
+    },
+    {
+      "description": "Update semver tool",
+      "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "https://raw.githubusercontent.com/fsaintjacques/semver-tool/(?<currentValue>.+)/src/semver"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "fsaintjacques/semver-tool"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This changes the versioning scheme for all images to semver.

The newest version is read from the registry and them bumped using [fsaintjacques/semver-tool](https://github.com/fsaintjacques/semver-tool).
With this change, we also enforce the PR titles to contain one of the necessary commit scopes.

After merging, I'll trigger a release for all images using the workflow dispatch for the build workflow.
