### PR TITLE
fix(major): ignore sha- tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,8 @@ jobs:
 
       - name: Get most recent tag
         id: tag
-        run: echo tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | last') >> $GITHUB_OUTPUT
+        # Some of our older tags are "sha-${checksum}", so we need to ignore them
+        run: echo tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | .[] | select(contains("sha-") | not)' | tail -n 1) >> $GITHUB_OUTPUT
 
       - name: Get commit scope
         id: commit-scope

--- a/images/ingress-nginx-default-backend/README.md
+++ b/images/ingress-nginx-default-backend/README.md
@@ -22,3 +22,5 @@ The error page priority is as follows:
 ## Page template
 
 The error page template was designed by [dkaramazov](https://codepen.io/dkaramazov) on CodePen.
+
+<!-- Remove me! This comment is used to bump the image version with the tagging changes. Remove it when you edit this file, please. -->

--- a/images/sshd/README.md
+++ b/images/sshd/README.md
@@ -9,3 +9,5 @@ This image sets up an SSHD server with STFTP enabled and a user `upload` with th
   - ssh_host_ed25519_key (`ssh-keygen -t ed25519`)
   - ssh_host_rsa_key (`ssh-keygen -t rsa`)
   - ssh_host_ecdsa_key (`ssh-keygen -t ecdsa`)
+
+<!-- Remove me! This comment is used to bump the image version with the tagging changes. Remove it when you edit this file, please. -->


### PR DESCRIPTION
We want to ignore the sha- tags that exist for some images.

This adds a comment to the README files of the affected images so that they will be rebuilt.