### PR TITLE
ci: update root hints fix

### DIFF
--- a/.github/workflows/update-unbound-root-hints.yml
+++ b/.github/workflows/update-unbound-root-hints.yml
@@ -8,6 +8,9 @@ jobs:
   update-root-hints:
     name: Update unbound root hints
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -19,6 +22,6 @@ jobs:
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           branch: chore/update-unbound-root-hints
-          title: "chore(unbound): update root hints"
+          title: "chore(patch): update root hints"
           body: |
             This updates the root.hints file for unbound. As usual, the Arch wiki has a good explanation: https://wiki.archlinux.org/title/unbound#Root_hints.


### PR DESCRIPTION
Fix for the root hints updates. Now with correct permissions and updates PR scope.
