### PR TITLE
ci: write permissions for unbound root hints update

### DIFF
--- a/.github/workflows/update-unbound-root-hints.yml
+++ b/.github/workflows/update-unbound-root-hints.yml
@@ -9,7 +9,7 @@ jobs:
     name: Update unbound root hints
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout


### PR DESCRIPTION
This needs write permissions to push to a branch.
