### PR TITLE
feat(major): add paperless-export image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request' && steps.dir-check.outputs.exists == 'true'
+        if: steps.dir-check.outputs.exists == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'push-image'))
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -101,7 +101,13 @@ jobs:
       - name: Get most recent tag
         id: tag
         # Some of our older tags are "sha-${checksum}", so we need to ignore them
-        run: echo tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | .[] | select(contains("sha-") | not)' | tail -n 1) >> $GITHUB_OUTPUT
+        # If no tags are published, assume 0.0.0 as old tag
+        run: |
+          tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | .[] | select(contains("sha-") | not)' | tail -n 1)
+          if [[ $tag -eq "" ]]; then
+            tag="0.0.0"
+          fi
+          echo tag="$tag" >> $GITHUB_OUTPUT
 
       - name: Get commit scope
         id: commit-scope
@@ -142,8 +148,10 @@ jobs:
             latest=false
           images: |
             ghcr.io/community-tooling/oci-images/${{ matrix.image }}
+
+          # If we're in a PR and pushing for the PR, use the SHA sum as tag, else use the defined version
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ contains(github.event.pull_request.labels.*.name, 'push-image') && github.sha || steps.version.outputs.version }}
 
       - name: Build and push
         if: ${{ steps.dir-check.outputs.exists == 'true' }}
@@ -151,7 +159,7 @@ jobs:
         with:
           context: images/${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'push-image') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,5 +26,14 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ steps.setup-python.outputs.python-version }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
+      - name: Install hadolint
+        run: |
+          set -x
+          echo $PATH
+          wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
+          ls -l /usr/local/bin/hadolint
+          chmod +x /usr/local/bin/hadolint
+          which hadolint
+
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_stages:
-  - commit
+  - pre-commit
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -17,4 +17,4 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
-      - id: hadolint-docker
+      - id: hadolint

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ renovate is configured to automatically apply the `major` and `minor` scope to t
 
 ## Contributing
 
-You need to have [pre-commit](pre-commit.com) installed and a container daemon running (for hadolint)
+You need to have installed:
+
+- [pre-commit](pre-commit.com)
+- [hadolint](https://github.com/hadolint/hadolint)
 
 Run `make init` after you have cloned the repository to set up pre-commit.
 

--- a/images/paperless-export/Dockerfile
+++ b/images/paperless-export/Dockerfile
@@ -1,0 +1,18 @@
+FROM busybox:1.37.0 AS extract
+
+# renovate: datasource=github-releases depName=just-containers/s6-overlay
+ARG S6_OVERLAY_VERSION=v3.2.0.2
+
+# https://github.com/just-containers/s6-overlay#using-cmd
+ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
+
+FROM ghcr.io/paperless-ngx/paperless-ngx:2.15.1
+
+# Replace the paperless s6 configuration with the default configuration.
+# This is needed so that paperless does not start
+RUN rm -r /etc/s6-overlay/s6-rc.d/*
+COPY --from=extract /etc/s6-overlay/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
+
+COPY export /usr/local/bin/export
+CMD ["/usr/local/bin/export"]

--- a/images/paperless-export/README.md
+++ b/images/paperless-export/README.md
@@ -1,0 +1,24 @@
+# paperless-export
+
+With [PR #8886](https://github.com/paperless-ngx/paperless-ngx/pull/8886), released with [v2.15.0](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.15.0) of paperless-ngx, the official docker image uses s6 as an overlay.
+
+While [s6 supports explicitly executing one command with the CMD instruction](https://github.com/just-containers/s6-overlay#using-cmd), the supporting services (e.g. redis) are always started when the container is started.
+
+This effectively renders the image unable to just perform the `document_exporter` command without doing anything else.
+
+Since using `docker exec` is the [only officially supported](https://github.com/paperless-ngx/paperless-ngx/issues/9631#issuecomment-2798823502) way to run the document_exporter, I (@morremeyer) decided to build this image.
+
+## What does it do?
+
+This image runs the paperless [`document_exporter`](https://docs.paperless-ngx.com/administration/#exporter) command with the `/export` target directory.
+
+To use it, start the container with your target directory mounted to `/export`.
+
+## How is it built?
+
+The image is built on top of the official paperless-ngx image, ensuring that dependencies etc. are always correct.
+
+There are two changes made:
+
+- The s6-overlay configuration is deleted and replaced with the default s6-overlay configuration, so that no services start when the container starts
+- The CMD is set to execute the [export](./export) script

--- a/images/paperless-export/export
+++ b/images/paperless-export/export
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec /usr/local/bin/document_exporter /export


### PR DESCRIPTION
## Overview

This PR does three things:

- add a paperless-export image
- switch hadolint to run locally, not via docker, since pre-commit does not play nice with podman for some reason
- adds the capability of adding the label "push-image" to a PR so that images built for a PR can be tested.

## paperless-export

The image is built on top of the official paperless-ngx image, ensuring that dependencies etc. are always correct.

There are two changes made:

- The s6-overlay configuration is deleted and replaced with the default s6-overlay configuration, so that no services start when the container starts
- The CMD is set to execute the [export](./export) script

For details, see the README.md in this commit.


