### PR TITLE
ci: ensure concurrency of 1 and chronological builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,11 @@ on:
 permissions:
   packages: write
 
+# We need the builds to run one after another chronologically
+# If they don't, an image for a newer commit might get an older version.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
+          hadolint --version
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,12 +28,8 @@ jobs:
 
       - name: Install hadolint
         run: |
-          set -x
-          echo $PATH
           wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
-          ls -l /usr/local/bin/hadolint
           chmod +x /usr/local/bin/hadolint
-          which hadolint
 
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
This ensures a concurrency of 1 and chronological builds.
