### PR TITLE
fix(patch): exclude SHA sums from version determination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         # Some of our older tags are "sha-${checksum}", so we need to ignore them
         # If no tags are published, assume 0.0.0 as old tag
         run: |
-          tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | .[] | select(contains("sha-") | not)' | tail -n 1)
+          tag=$(skopeo list-tags "docker://ghcr.io/community-tooling/oci-images/${{ matrix.image }}" | jq -r '.Tags | sort | .[] | select(contains("sha-") | not)' | grep -E '[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1)
           if [[ $tag -eq "" ]]; then
             tag="0.0.0"
           fi
@@ -134,7 +134,7 @@ jobs:
           if [[ "$scope" =~ ^(major|minor|patch)$ ]]; then
             echo scope=$scope >> $GITHUB_OUTPUT
           else
-            echo "::error title=Invalid commit scope::The commit scope is not an allowed value, check the README section on versioning"
+            echo "::error title=Invalid commit scope::The commit scope is not an allowed value, check the README section on versioning. The PR title must have the correct scope."
             exit 1
           fi
 

--- a/images/paperless-export/export
+++ b/images/paperless-export/export
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+# This does the same as calling "document_exporter /export" when exec-ing into the container
 exec /usr/local/bin/document_exporter /export


### PR DESCRIPTION
This fixes an issue where sha sums were not filtered when determining the latest version.

Now, all output is filtered to only contain semver versions.
