### PR TITLE
feat(major): Add kubectl + bash image

### DIFF
--- a/images/kubectl/Dockerfile
+++ b/images/kubectl/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+
+ARG TARGETARCH
+
+# renovate: datasource=github-tags depName=kubernetes/kubectl extractVersion=^kubernetes-(?<version>.*)$
+ARG KUBECTL_VERSION=1.33.3
+
+ARG URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl"
+
+# Pinning the versions here does not work well since we can't upgrade the alpine version and the
+# versions with the same PR, see https://github.com/renovatebot/renovate/discussions/10452.
+# Therefore, we opt to not do this at all for now.
+#
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+  bash \
+  curl \
+  jq
+
+RUN curl -Lo /usr/local/bin/kubectl "$URL" && \
+  chmod +x /usr/local/bin/kubectl && \
+  kubectl version --client=true
+
+ENTRYPOINT ["/bin/bash"]

--- a/images/kubectl/README.md
+++ b/images/kubectl/README.md
@@ -1,0 +1,16 @@
+# kubectl
+
+Alpine-based image with up-to-date kubectl versions.
+
+This image also includes:
+
+- bash, to execute bash scripts
+- curl, for HTTP requests
+- jq, to parse JSON
+
+## Additional binaries
+
+If you want an additional binary in this image, please consider installing it only when needed.
+We specifically do not want this image to be a swiss army knife that can do everything, but covers only the most common use cases.
+
+Overly specific dependencies will make maintenance unfeasible for us.


### PR DESCRIPTION
This adds an image for kubectl with bash and curl.

It should be helpful for anyone migrating from bitnami/kubectl, but is not intended as a drop-in-replacement.

Some things should work from the get-go, some might not at all.
