### PR TITLE
feat(minor): add mariadb-connector-c

### DIFF
--- a/images/restic-mysqlclient/Dockerfile
+++ b/images/restic-mysqlclient/Dockerfile
@@ -1,4 +1,4 @@
 FROM --platform=${TARGETPLATFORM} restic/restic:0.18.0@sha256:4cf4a61ef9786f4de53e9de8c8f5c040f33830eb0a10bf3d614410ee2fcb6120
 
 # hadolint ignore=DL3018
-RUN apk add --update --no-cache mysql-client
+RUN apk add --update --no-cache mariadb-client mariadb-connector-c


### PR DESCRIPTION
This adds the mariadb-connector-c package which enables the MySQL 8 default caching_sha2_password algorithm.
Also installs mariadb-client instead of mysql-client, which was an alias anyways.
